### PR TITLE
♻️ Refatora a classe Task

### DIFF
--- a/include/task/blinky.hpp
+++ b/include/task/blinky.hpp
@@ -27,9 +27,7 @@ public:
      */
     BlinkyTask(const rfidoor::peripheral::Led& led,
                uint32_t blinky_frequency_ms, 
-               const char* name = default_name,
-               uint32_t stack_size = default_stack_size,
-               task_priority_t priority = default_priority);
+               const task_config_t& config = default_config);
 
     /**
      * @brief Override of the mother class Task init function  

--- a/include/task/blinky.hpp
+++ b/include/task/blinky.hpp
@@ -26,7 +26,7 @@ public:
      * @param blinky_frequency_ms Frequency to blink the LED in miliseconds
      */
     BlinkyTask(const rfidoor::peripheral::Led& led,
-               uint32_t blinky_frequency_ms, 
+               uint32_t blinky_frequency_ms,
                const task_config_t& config = default_config);
 
     /**

--- a/include/task/task.hpp
+++ b/include/task/task.hpp
@@ -73,7 +73,7 @@ public:
      *
      * @param time_to_sleep_ms Time to task sleep in miliseconds
      */
-    static void task_sleep_ms(uint32_t time_to_sleep_ms);
+    static const void task_sleep_ms(const uint32_t& time_to_sleep_ms);
 
 protected:
     /**

--- a/include/task/task.hpp
+++ b/include/task/task.hpp
@@ -28,11 +28,18 @@ enum task_priority_t {
 };
 
 /**
- * @brief Public variables that correspond to the default values of the abstract Task class 
+ * @brief Struct to be passed to Task constructor
  */
-extern const char* default_name;
-extern const uint32_t default_stack_size;  // words
-extern const task_priority_t default_priority;
+typedef struct task_config_t {
+    const char* name;
+    uint32_t stack_size;
+    task_priority_t priority;
+} task_config_t;
+
+/**
+ * @brief Public variable that correspond to the default values of the abstract Task class 
+ */
+extern const task_config_t default_config;
 
 /**
  * @brief Class for a generic Task
@@ -42,11 +49,14 @@ public:
     /**
      * @brief Constructor for the generic Task class
      *
-     * @param name String that represents the name of the refered task
-     * @param stack_size Size of the stack reserved for task in words
-     * @param priority The priority of the task that will be runned
+     * @param task_config_t Configuration of the task
      */
-    Task(const char* name = default_name, uint32_t stack_size = default_stack_size, task_priority_t priority = default_priority);
+    Task(const task_config_t& config = default_config);
+
+    /**
+     * @brief Function that calls xTaskCreate from FreeRTOS
+     */
+    const void create_task();
 
     /**
      * @brief Init function to be overrided by inheriting classes
@@ -72,6 +82,12 @@ protected:
      * @param params RTOS required parameters
      */
     static void entry_function_wrapper(void* params);
+
+private:
+    /**
+     * @brief Configuration type for class configuring
+     */
+    const task_config_t configuration;
 
     /**
      * @brief Handle for the task, required by xTaskCreate RTOS function

--- a/include/task_scheme.hpp
+++ b/include/task_scheme.hpp
@@ -1,0 +1,20 @@
+/**
+ * @file task_scheme.hpp
+ *
+ * @brief Configuration file of all tasks
+ *
+ * @date 06/2024
+ */
+
+
+#include "task/task.hpp"
+
+namespace rfidoor::task {
+
+task_config_t blinky_config = {
+    .name = "blinkyTask",
+    .stack_size = 1000,
+    .priority = LOW_PRIORITY
+};
+
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,14 +1,12 @@
 #include <task/blinky.hpp>
 #include <pinout.hpp>
+#include <task_scheme.hpp>
 
-namespace rfidoor::pinout {
 
 const uint32_t blinky_frequency_ms{500};
 
 // Tasks initializations
- rfidoor::task::BlinkyTask blinky_task(board_led, blinky_frequency_ms, "blinkyTask");
-
-}  // rfidoor::pinout
+ rfidoor::task::BlinkyTask blinky_task(rfidoor::pinout::board_led, blinky_frequency_ms, rfidoor::task::blinky_config);
 
 void setup() {
   rfidoor::pinout::lcd.init();
@@ -17,9 +15,11 @@ void setup() {
 	rfidoor::pinout::lcd.setCursor(2,1);
 	rfidoor::pinout::lcd.print("Chupa Tsuzuki");
   rfidoor::pinout::lcd.write_special_char(rfidoor::peripheral::SKULL_SPECIAL_CHAR);
+
+  blinky_task.create_task();
 }
 
 void loop() {
-  rfidoor::pinout::board_led.toggle();
-  delay(500);
+  // rfidoor::pinout::board_led.toggle();
+  // delay(500);
 }

--- a/src/task/blinky.cpp
+++ b/src/task/blinky.cpp
@@ -2,8 +2,8 @@
 
 namespace rfidoor::task {
 
-BlinkyTask::BlinkyTask(const rfidoor::peripheral::Led& led, uint32_t blinky_frequency_ms, const char* name, uint32_t stack_size, task_priority_t priority) : 
-                       Task(name, stack_size, priority), 
+BlinkyTask::BlinkyTask(const rfidoor::peripheral::Led& led, uint32_t blinky_frequency_ms, const task_config_t& config) : 
+                       Task(config), 
                        led{led}, 
                        blinky_frequency_ms{blinky_frequency_ms} {  }
 

--- a/src/task/task.cpp
+++ b/src/task/task.cpp
@@ -32,7 +32,7 @@ const void Task::create_task() {
     );
 }
 
-void Task::task_sleep_ms(uint32_t time_to_sleep_ms) {
+const void Task::task_sleep_ms(const uint32_t& time_to_sleep_ms) {
     vTaskDelay(pdMS_TO_TICKS(time_to_sleep_ms));
 }
 

--- a/src/task/task.cpp
+++ b/src/task/task.cpp
@@ -11,21 +11,24 @@
 namespace rfidoor::task {
 
 /**
- * @brief Public variables that correspond to the default values of the abstract Task class 
+ * @brief Public variable that correspond to the default values of the abstract Task class 
  */
-const char* default_name = "";
-const uint32_t default_stack_size = 1000;  // words
-const task_priority_t default_priority = LOW_PRIORITY;
+const task_config_t default_config = {
+    .name = "",
+    .stack_size = 1000,
+    .priority = LOW_PRIORITY
+};
 
+Task::Task(const task_config_t& config) : configuration{config} { }
 
-Task::Task(const char* name, uint32_t stack_size, task_priority_t priority) {
+const void Task::create_task() {
     xTaskCreate(
-        entry_function_wrapper,  // Task function
-        name,                    // Name of the task (for debugging)
-        stack_size,              // Stack size (in words)
-        this,                    // Task input parameter
-        priority,                // Priority of the task
-        &this->task_handle       // Task handle
+        entry_function_wrapper,          // Task function
+        this->configuration.name,        // Name of the task (for debugging)
+        this->configuration.stack_size,  // Stack size (in words)
+        this,                            // Task input parameter
+        this->configuration.priority,    // Priority of the task
+        &this->task_handle               // Task handle
     );
 }
 


### PR DESCRIPTION
Essa PR refatora a classe task, com duas grandes mudanças:

1. Agora as tasks podem ser construídas a partir de um único parâmetro de config, do tipo task_config_t
2. Agora existe um header task_scheme.hpp, que contém todos os configs de todas as tasks
3. As tasks agora possuem um método `Task::create_task()`, que é responsável por chamar a função xTaskCreate() do FreeRTOS. Isso foi feito porque eu descobri que o LCD só pode ser inicializado dentro da função setup, o que seria um problema para qualquer task que usasse o LCD, uma vez que as tasks são construídas fora da função setup. Dessa forma, a chamada da função xTaskCreate não pode ser no construtor da Task, mas sim em um método separado, que (idealmente), só será chamado quando todos os periféricos forem corretamente inicializados