### PR TITLE
Implementa as classes para semaphores

### DIFF
--- a/include/pinout.hpp
+++ b/include/pinout.hpp
@@ -16,7 +16,7 @@
 #include <peripheral/servo.hpp>
 
 namespace rfidoor::pinout {
-  
+
 // LCD pinout
 extern const uint8_t lcd_sda_pin;
 extern const uint8_t lcd_scl_pin;

--- a/include/queue/queue.hpp
+++ b/include/queue/queue.hpp
@@ -39,19 +39,19 @@ public:
 
   /**
    * @brief Publish function
-   * 
+   *
    * @param message Message to be published
    */
   void publish(T message);
 
   /**
    * @brief Function to read queue
-   * 
+   *
    * @param buffer Pointer to the buffer where the message will be stored
-   * 
+   *
    * @return true if the message was successfully read, false otherwise
    */
-  bool read(T* buffer);
+  bool read(T *buffer);
 
 private:
   /**

--- a/include/semaphore/binary.hpp
+++ b/include/semaphore/binary.hpp
@@ -19,6 +19,11 @@ namespace rfidoor::semaphore {
 class BinarySemaphore : public Semaphore {
 public:
     /**
+     * @brief Construct a new Binary Semaphore object
+     */
+    BinarySemaphore(void);    
+
+    /**
      * @brief Override of the mother class Semaphore create_semaphore function
      * 
      * @return SemaphoreHandle_t Handle for the semaphore

--- a/include/semaphore/binary.hpp
+++ b/include/semaphore/binary.hpp
@@ -1,0 +1,30 @@
+/**
+ * @file binary.hpp
+ * 
+ * @brief Binary Semaphore class header
+ * 
+ * @date 06/2024
+ */
+
+#ifndef __BINARY_HPP__
+#define __BINARY_HPP__
+
+#include "semaphore/semaphore.hpp"
+
+namespace rfidoor::semaphore {
+
+/**
+ * @brief Class for the Binary Semaphore
+ */
+class BinarySemaphore : public Semaphore {
+public:
+    /**
+     * @brief Override of the mother class Semaphore create_semaphore function
+     * 
+     * @return SemaphoreHandle_t Handle for the semaphore
+     */
+    virtual SemaphoreHandle_t create_semaphore() override;
+};
+}
+
+#endif // __BINARY_HPP__

--- a/include/semaphore/binary.hpp
+++ b/include/semaphore/binary.hpp
@@ -19,11 +19,6 @@ namespace rfidoor::semaphore {
 class BinarySemaphore : public Semaphore {
 public:
     /**
-     * @brief Construct a new Binary Semaphore object
-     */
-    BinarySemaphore(void);    
-
-    /**
      * @brief Override of the mother class Semaphore create_semaphore function
      * 
      * @return SemaphoreHandle_t Handle for the semaphore

--- a/include/semaphore/binary.hpp
+++ b/include/semaphore/binary.hpp
@@ -1,8 +1,8 @@
 /**
  * @file binary.hpp
- * 
+ *
  * @brief Binary Semaphore class header
- * 
+ *
  * @date 06/2024
  */
 
@@ -18,13 +18,13 @@ namespace rfidoor::semaphore {
  */
 class BinarySemaphore : public Semaphore {
 public:
-    /**
-     * @brief Override of the mother class Semaphore create_semaphore function
-     * 
-     * @return SemaphoreHandle_t Handle for the semaphore
-     */
-    virtual SemaphoreHandle_t create_semaphore() override;
+  /**
+   * @brief Override of the mother class Semaphore create_semaphore function
+   *
+   * @return SemaphoreHandle_t Handle for the semaphore
+   */
+  virtual SemaphoreHandle_t create_semaphore() override;
 };
-}
+} // namespace rfidoor::semaphore
 
 #endif // __BINARY_HPP__

--- a/include/semaphore/mutex.hpp
+++ b/include/semaphore/mutex.hpp
@@ -1,0 +1,30 @@
+/**
+ * @file mutex.hpp
+ * 
+ * @brief Mutex Semaphore class header
+ * 
+ * @date 06/2024
+ */
+
+#ifndef __MUTEX_HPP__
+#define __MUTEX_HPP__
+
+#include "semaphore/semaphore.hpp"
+
+namespace rfidoor::semaphore {
+
+/**
+ * @brief Class for the Mutex Semaphore
+ */
+class MutexSemaphore : public Semaphore {
+public:
+    /**
+     * @brief Override of the mother class Semaphore create_semaphore function
+     * 
+     * @return SemaphoreHandle_t Handle for the semaphore
+     */
+    virtual SemaphoreHandle_t create_semaphore() override;
+};
+}
+
+#endif // __MUTEX_HPP__

--- a/include/semaphore/mutex.hpp
+++ b/include/semaphore/mutex.hpp
@@ -1,8 +1,8 @@
 /**
  * @file mutex.hpp
- * 
+ *
  * @brief Mutex Semaphore class header
- * 
+ *
  * @date 06/2024
  */
 
@@ -18,13 +18,13 @@ namespace rfidoor::semaphore {
  */
 class MutexSemaphore : public Semaphore {
 public:
-    /**
-     * @brief Override of the mother class Semaphore create_semaphore function
-     * 
-     * @return SemaphoreHandle_t Handle for the semaphore
-     */
-    virtual SemaphoreHandle_t create_semaphore() override;
+  /**
+   * @brief Override of the mother class Semaphore create_semaphore function
+   *
+   * @return SemaphoreHandle_t Handle for the semaphore
+   */
+  virtual SemaphoreHandle_t create_semaphore() override;
 };
-}
+} // namespace rfidoor::semaphore
 
 #endif // __MUTEX_HPP__

--- a/include/semaphore/semaphore.hpp
+++ b/include/semaphore/semaphore.hpp
@@ -1,0 +1,51 @@
+/**
+ * @file semaphore.hpp
+ * 
+ * @brief Generic semaphore class header
+ * 
+ * @date 06/2024
+ */
+
+#ifndef __SEMAPHORE_HPP__
+#define __SEMAPHORE_HPP__
+
+#include <Arduino.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+namespace rfidoor::semaphore {
+
+class Semaphore {
+public:
+  /**
+   * @brief Constructor for the generic Semaphore class
+   */
+  Semaphore(void);
+
+  /**
+   * @brief Create semaphore function to be overriden by the derived class
+   * 
+   * @return SemaphoreHandle_t Handle for the semaphore
+   */
+  virtual SemaphoreHandle_t create_semaphore() = 0;
+
+  /**
+   * @brief Function that calls xSemaphoreGive from FreeRTOS
+   */
+  const void give_semaphore();
+
+  /**
+   * @brief Function that calls xSemaphoreTake from FreeRTOS
+   */
+  const void take_semaphore();
+
+private:
+    /**
+     * @brief Handle for the semaphore, required by xSemaphoreCreateBinary RTOS function
+     */
+    SemaphoreHandle_t semaphore_handle;
+};
+    
+} // namespace rfidoor::semaphore
+
+#endif // __SEMAPHORE_HPP__

--- a/include/semaphore/semaphore.hpp
+++ b/include/semaphore/semaphore.hpp
@@ -27,7 +27,7 @@ public:
    * 
    * @return SemaphoreHandle_t Handle for the semaphore
    */
-  virtual SemaphoreHandle_t create_semaphore() = 0;
+  virtual SemaphoreHandle_t create_semaphore() { return NULL; };
 
   /**
    * @brief Function that calls xSemaphoreGive from FreeRTOS
@@ -39,7 +39,7 @@ public:
    */
   const void take_semaphore();
 
-private:
+protected:
     /**
      * @brief Handle for the semaphore, required by xSemaphoreCreateBinary RTOS function
      */

--- a/include/semaphore/semaphore.hpp
+++ b/include/semaphore/semaphore.hpp
@@ -1,8 +1,8 @@
 /**
  * @file semaphore.hpp
- * 
+ *
  * @brief Generic semaphore class header
- * 
+ *
  * @date 06/2024
  */
 
@@ -24,7 +24,7 @@ public:
 
   /**
    * @brief Create semaphore function to be overriden by the derived class
-   * 
+   *
    * @return SemaphoreHandle_t Handle for the semaphore
    */
   virtual SemaphoreHandle_t create_semaphore() { return NULL; };
@@ -40,12 +40,13 @@ public:
   const void take_semaphore();
 
 protected:
-    /**
-     * @brief Handle for the semaphore, required by xSemaphoreCreateBinary RTOS function
-     */
-    SemaphoreHandle_t semaphore_handle;
+  /**
+   * @brief Handle for the semaphore, required by xSemaphoreCreateBinary RTOS
+   * function
+   */
+  SemaphoreHandle_t semaphore_handle;
 };
-    
+
 } // namespace rfidoor::semaphore
 
 #endif // __SEMAPHORE_HPP__

--- a/include/semaphore_scheme.hpp
+++ b/include/semaphore_scheme.hpp
@@ -1,22 +1,22 @@
 /**
  * @file semaphore_scheme.hpp
- * 
+ *
  * @brief Configuration file of all semaphores
- * 
+ *
  * @date 06/2024
  */
 
 #ifndef __SEMAPHORE_SCHEME_HPP__
 #define __SEMAPHORE_SCHEME_HPP__
 
-#include "semaphore/semaphore.hpp"
 #include "semaphore/binary.hpp"
+#include "semaphore/semaphore.hpp"
 
 namespace rfidoor::semaphore {
 
 /**
  * @brief Binary semaphore example
- */ 
+ */
 extern BinarySemaphore binary_semaphore_example;
 
 }; // namespace rfidoor::semaphore

--- a/include/semaphore_scheme.hpp
+++ b/include/semaphore_scheme.hpp
@@ -1,0 +1,24 @@
+/**
+ * @file semaphore_scheme.hpp
+ * 
+ * @brief Configuration file of all semaphores
+ * 
+ * @date 06/2024
+ */
+
+#ifndef __SEMAPHORE_SCHEME_HPP__
+#define __SEMAPHORE_SCHEME_HPP__
+
+#include "semaphore/semaphore.hpp"
+#include "semaphore/binary.hpp"
+
+namespace rfidoor::semaphore {
+
+/**
+ * @brief Binary semaphore example
+ */ 
+extern BinarySemaphore binary_semaphore_example;
+
+}; // namespace rfidoor::semaphore
+
+#endif // __SEMAPHORE_SCHEME_HPP__

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,13 +4,12 @@
 #include <task/state_machine.hpp>
 #include <task_scheme.hpp>
 
-void setup()
-{
+void setup() {
   Serial.begin(9600);
 
   rfidoor::task::blinky_task.create_task();
   rfidoor::task::state_machine_task.create_task();
-  
+
   rfidoor::pinout::lcd.init();
   // rfidoor::pinout::lcd.set_cursor(0, 0);
   // rfidoor::pinout::lcd.write("Hello, world!");
@@ -34,16 +33,13 @@ void setup()
   delay(1000); // Wait for 1 second
 }
 
-void loop()
-{
+void loop() {
   char key = rfidoor::pinout::keyboard.getKey();
 
-  if (key)
-  { 
+  if (key) {
     rfidoor::pinout::lcd.write_char_with_increment(key);
 
-    if (key == '*')
-    {
+    if (key == '*') {
       rfidoor::queue::events_queue.publish(rfidoor::task::SENHA_INVALIDA);
     } else {
       rfidoor::queue::events_queue.publish(rfidoor::task::TECLA);

--- a/src/pinout.cpp
+++ b/src/pinout.cpp
@@ -1,8 +1,8 @@
 /**
  * @file pinout.cpp
- * 
+ *
  * @brief Define target specific configuration variables
- * 
+ *
  * @date 06/2024
  */
 

--- a/src/semaphore/binary.cpp
+++ b/src/semaphore/binary.cpp
@@ -1,8 +1,8 @@
 /**
  * @file binary.cpp
- * 
+ *
  * @brief Binary Semaphore class implementation
- * 
+ *
  * @date 06/2024
  */
 
@@ -11,7 +11,7 @@
 namespace rfidoor::semaphore {
 
 SemaphoreHandle_t BinarySemaphore::create_semaphore() {
-    return xSemaphoreCreateBinary();
+  return xSemaphoreCreateBinary();
 }
 
 } // namespace rfidoor::semaphore

--- a/src/semaphore/binary.cpp
+++ b/src/semaphore/binary.cpp
@@ -10,10 +10,6 @@
 
 namespace rfidoor::semaphore {
 
-BinarySemaphore::BinarySemaphore(void) {
-    this->semaphore_handle = this->create_semaphore();
-}
-
 SemaphoreHandle_t BinarySemaphore::create_semaphore() {
     return xSemaphoreCreateBinary();
 }

--- a/src/semaphore/binary.cpp
+++ b/src/semaphore/binary.cpp
@@ -1,0 +1,17 @@
+/**
+ * @file binary.cpp
+ * 
+ * @brief Binary Semaphore class implementation
+ * 
+ * @date 06/2024
+ */
+
+#include "semaphore/binary.hpp"
+
+namespace rfidoor::semaphore {
+
+SemaphoreHandle_t BinarySemaphore::create_semaphore() {
+    return xSemaphoreCreateBinary();
+}
+
+} // namespace rfidoor::semaphore

--- a/src/semaphore/binary.cpp
+++ b/src/semaphore/binary.cpp
@@ -10,6 +10,10 @@
 
 namespace rfidoor::semaphore {
 
+BinarySemaphore::BinarySemaphore(void) {
+    this->semaphore_handle = this->create_semaphore();
+}
+
 SemaphoreHandle_t BinarySemaphore::create_semaphore() {
     return xSemaphoreCreateBinary();
 }

--- a/src/semaphore/mutex.cpp
+++ b/src/semaphore/mutex.cpp
@@ -1,8 +1,8 @@
 /**
  * @file mutex.cpp
- * 
+ *
  * @brief Mutex Semaphore class implementation
- * 
+ *
  * @date 06/2024
  */
 
@@ -11,7 +11,7 @@
 namespace rfidoor::semaphore {
 
 SemaphoreHandle_t MutexSemaphore::create_semaphore() {
-    return xSemaphoreCreateMutex();
+  return xSemaphoreCreateMutex();
 }
 
 } // namespace rfidoor::semaphore

--- a/src/semaphore/mutex.cpp
+++ b/src/semaphore/mutex.cpp
@@ -1,0 +1,17 @@
+/**
+ * @file mutex.cpp
+ * 
+ * @brief Mutex Semaphore class implementation
+ * 
+ * @date 06/2024
+ */
+
+#include "semaphore/mutex.hpp"
+
+namespace rfidoor::semaphore {
+
+SemaphoreHandle_t MutexSemaphore::create_semaphore() {
+    return xSemaphoreCreateMutex();
+}
+
+} // namespace rfidoor::semaphore

--- a/src/semaphore/semaphore.cpp
+++ b/src/semaphore/semaphore.cpp
@@ -1,8 +1,8 @@
 /**
  * @file semaphore.cpp
- * 
+ *
  * @brief Generic semaphore class implementation
- * 
+ *
  * @date 06/2024
  */
 
@@ -11,15 +11,15 @@
 namespace rfidoor::semaphore {
 
 Semaphore::Semaphore(void) {
-    this->semaphore_handle = this->create_semaphore();
+  this->semaphore_handle = this->create_semaphore();
 }
 
 const void Semaphore::give_semaphore() {
-    xSemaphoreGive(this->semaphore_handle);
+  xSemaphoreGive(this->semaphore_handle);
 }
 
 const void Semaphore::take_semaphore() {
-    xSemaphoreTake(this->semaphore_handle, portMAX_DELAY);
+  xSemaphoreTake(this->semaphore_handle, portMAX_DELAY);
 }
 
-}
+} // namespace rfidoor::semaphore

--- a/src/semaphore/semaphore.cpp
+++ b/src/semaphore/semaphore.cpp
@@ -1,0 +1,25 @@
+/**
+ * @file semaphore.cpp
+ * 
+ * @brief Generic semaphore class implementation
+ * 
+ * @date 06/2024
+ */
+
+#include "semaphore/semaphore.hpp"
+
+namespace rfidoor::semaphore {
+
+Semaphore::Semaphore(void) {
+    this->semaphore_handle = this->create_semaphore();
+}
+
+const void Semaphore::give_semaphore() {
+    xSemaphoreGive(this->semaphore_handle);
+}
+
+const void Semaphore::take_semaphore() {
+    xSemaphoreTake(this->semaphore_handle, portMAX_DELAY);
+}
+
+}

--- a/src/semaphore/semaphore.cpp
+++ b/src/semaphore/semaphore.cpp
@@ -10,6 +10,8 @@
 
 namespace rfidoor::semaphore {
 
+const uint32_t semaphore_delay{portMAX_DELAY};
+
 Semaphore::Semaphore(void) {
   this->semaphore_handle = this->create_semaphore();
 }
@@ -19,7 +21,7 @@ const void Semaphore::give_semaphore() {
 }
 
 const void Semaphore::take_semaphore() {
-  xSemaphoreTake(this->semaphore_handle, portMAX_DELAY);
+  xSemaphoreTake(this->semaphore_handle, semaphore_delay);
 }
 
 } // namespace rfidoor::semaphore

--- a/src/semaphore_scheme.cpp
+++ b/src/semaphore_scheme.cpp
@@ -1,0 +1,15 @@
+/**
+ * @file semaphore_scheme.cpp
+ * 
+ * @brief Define configuration file of all semaphores variables
+ * 
+ * @date 06/2024
+ */
+
+#include "semaphore_scheme.hpp"
+
+namespace rfidoor::semaphore {
+
+BinarySemaphore binary_semaphore_example;
+
+} // namespace rfidoor::semaphore

--- a/src/semaphore_scheme.cpp
+++ b/src/semaphore_scheme.cpp
@@ -1,8 +1,8 @@
 /**
  * @file semaphore_scheme.cpp
- * 
+ *
  * @brief Define configuration file of all semaphores variables
- * 
+ *
  * @date 06/2024
  */
 

--- a/src/task/state_machine.cpp
+++ b/src/task/state_machine.cpp
@@ -6,8 +6,8 @@
  * @date 06/2024
  */
 
-#include "queue_scheme.hpp"
 #include "task/state_machine.hpp"
+#include "queue_scheme.hpp"
 
 namespace rfidoor::task {
 
@@ -21,17 +21,19 @@ void StateMachineTask::init() {
   for (int state = 0; state < NUM_STATES; state++) {
     for (int event = 0; event < NUM_EVENTS; event++) {
       this->action_state_machine_table[state][event] = NENHUMA_ACAO;
-      this->next_state_state_machine_table[state][event] = (state_t) state;
+      this->next_state_state_machine_table[state][event] = (state_t)state;
     }
   }
 
   // Set the actions and next states for each event for TRANCADA_IDLE
-  this->next_state_state_machine_table[TRANCADA_IDLE][SINAL_INVALIDO] = TRANCADA_IDLE;
+  this->next_state_state_machine_table[TRANCADA_IDLE][SINAL_INVALIDO] =
+      TRANCADA_IDLE;
   this->action_state_machine_table[TRANCADA_IDLE][SINAL_INVALIDO] = A03;
   this->next_state_state_machine_table[TRANCADA_IDLE][SINAL_VALIDO] =
       DESTRANCADA_FECHADA;
   this->action_state_machine_table[TRANCADA_IDLE][SINAL_VALIDO] = A04;
-  this->next_state_state_machine_table[TRANCADA_IDLE][BOTAO] = DESTRANCADA_FECHADA;
+  this->next_state_state_machine_table[TRANCADA_IDLE][BOTAO] =
+      DESTRANCADA_FECHADA;
   this->action_state_machine_table[TRANCADA_IDLE][BOTAO] = A01;
   this->next_state_state_machine_table[TRANCADA_IDLE][TECLA] = DIGITANDO_SENHA;
   this->action_state_machine_table[TRANCADA_IDLE][TECLA] = A02;
@@ -43,9 +45,11 @@ void StateMachineTask::init() {
   this->next_state_state_machine_table[DIGITANDO_SENHA][SINAL_VALIDO] =
       DESTRANCADA_FECHADA;
   this->action_state_machine_table[DIGITANDO_SENHA][SINAL_VALIDO] = A04;
-  this->next_state_state_machine_table[DIGITANDO_SENHA][BOTAO] = DESTRANCADA_FECHADA;
+  this->next_state_state_machine_table[DIGITANDO_SENHA][BOTAO] =
+      DESTRANCADA_FECHADA;
   this->action_state_machine_table[DIGITANDO_SENHA][BOTAO] = A01;
-  this->next_state_state_machine_table[DIGITANDO_SENHA][TIMEOUT] = TRANCADA_IDLE;
+  this->next_state_state_machine_table[DIGITANDO_SENHA][TIMEOUT] =
+      TRANCADA_IDLE;
   this->action_state_machine_table[DIGITANDO_SENHA][TIMEOUT] = A05;
   this->next_state_state_machine_table[DIGITANDO_SENHA][SENHA_INVALIDA] =
       TRANCADA_IDLE;
@@ -55,7 +59,8 @@ void StateMachineTask::init() {
   this->action_state_machine_table[DIGITANDO_SENHA][SENHA_VALIDA] = A07;
 
   // Set the actions and next states for each event for DESTRANCADA_FECHADA
-  this->next_state_state_machine_table[DESTRANCADA_FECHADA][TIMEOUT] = TRANCADA_IDLE;
+  this->next_state_state_machine_table[DESTRANCADA_FECHADA][TIMEOUT] =
+      TRANCADA_IDLE;
   this->action_state_machine_table[DESTRANCADA_FECHADA][TIMEOUT] = A08;
   this->next_state_state_machine_table[DESTRANCADA_FECHADA][ABRIR] = ABERTA;
   this->action_state_machine_table[DESTRANCADA_FECHADA][ABRIR] = A09;
@@ -76,16 +81,14 @@ void StateMachineTask::init() {
 }
 
 void StateMachineTask::spin() {
-    if (rfidoor::queue::events_queue.read(&(this->event)) == pdPASS) {
-        this->action = this->get_action();
-        this->state = this->get_next_state();
-        this->execute_action();  
-    }
+  if (rfidoor::queue::events_queue.read(&(this->event)) == pdPASS) {
+    this->action = this->get_action();
+    this->state = this->get_next_state();
+    this->execute_action();
+  }
 }
 
-state_t StateMachineTask::get_state() {
-  return this->state;
-}
+state_t StateMachineTask::get_state() { return this->state; }
 
 state_t StateMachineTask::get_next_state() {
   return this->next_state_state_machine_table[this->state][this->event];
@@ -96,65 +99,65 @@ action_t StateMachineTask::get_action() {
 }
 
 void StateMachineTask::execute_action() {
-    switch (this->action) {
-    case A01:
-        // destranca e display botao
-        break;
-    case A02:
-        // display padrao senha e vai pro tratamento de senha
-        rfidoor::pinout::lcd.set_cursor(0, 0);
-        rfidoor::pinout::lcd.write("OMG SENHA!      ");
-        rfidoor::pinout::lcd.set_cursor(1, 1);
-        break;
-    case A03:
-        // display sinal invalido
-        break;
-    case A04:
-        // destranca e display sinal valido
-        break;
-    case A05:
-        // apaga display
-        break;
-    case A06:
-        // display senha invalida e display padrão
-        rfidoor::pinout::lcd.clear();
-        rfidoor::pinout::lcd.set_cursor(0, 0);
-        rfidoor::pinout::lcd.write("SENHA INVALIDA!");
-        delay(2000);
-        rfidoor::pinout::lcd.clear();
-        rfidoor::pinout::lcd.set_cursor(0, 0);
-        rfidoor::pinout::lcd.write("Digite a senha ");
-        rfidoor::pinout::lcd.write_special_char(
-            rfidoor::peripheral::LOCK_SPECIAL_CHAR);
-        rfidoor::pinout::lcd.set_cursor(0, 1);
-        break;
-    case A07:
-        // destranca e display senha valida
-        break;
-    case A08:
-        // tranca e display padrão
-        break;
-    case A09:
-        // desativa timeout e display porta aberta
-        break;
-    case A10:
-        // ativa timeout e display porta destrancada fechada
-        break;
-    case A11:
-        // habilitar registro e display registro
-        break;
-    case A12:
-        // desabilita registro e display sinal cadastrado
-        break;
-    case A13:
-        // desabilita registro e display senha cadastrado
-        break;
-    case A14:
-        // desabilita registro e display registro cancelado
-        break;
-    default:
-        break;
-    }
+  switch (this->action) {
+  case A01:
+    // destranca e display botao
+    break;
+  case A02:
+    // display padrao senha e vai pro tratamento de senha
+    rfidoor::pinout::lcd.set_cursor(0, 0);
+    rfidoor::pinout::lcd.write("OMG SENHA!      ");
+    rfidoor::pinout::lcd.set_cursor(1, 1);
+    break;
+  case A03:
+    // display sinal invalido
+    break;
+  case A04:
+    // destranca e display sinal valido
+    break;
+  case A05:
+    // apaga display
+    break;
+  case A06:
+    // display senha invalida e display padrão
+    rfidoor::pinout::lcd.clear();
+    rfidoor::pinout::lcd.set_cursor(0, 0);
+    rfidoor::pinout::lcd.write("SENHA INVALIDA!");
+    delay(2000);
+    rfidoor::pinout::lcd.clear();
+    rfidoor::pinout::lcd.set_cursor(0, 0);
+    rfidoor::pinout::lcd.write("Digite a senha ");
+    rfidoor::pinout::lcd.write_special_char(
+        rfidoor::peripheral::LOCK_SPECIAL_CHAR);
+    rfidoor::pinout::lcd.set_cursor(0, 1);
+    break;
+  case A07:
+    // destranca e display senha valida
+    break;
+  case A08:
+    // tranca e display padrão
+    break;
+  case A09:
+    // desativa timeout e display porta aberta
+    break;
+  case A10:
+    // ativa timeout e display porta destrancada fechada
+    break;
+  case A11:
+    // habilitar registro e display registro
+    break;
+  case A12:
+    // desabilita registro e display sinal cadastrado
+    break;
+  case A13:
+    // desabilita registro e display senha cadastrado
+    break;
+  case A14:
+    // desabilita registro e display registro cancelado
+    break;
+  default:
+    break;
+  }
 }
 
-}  // namespace rfidoor::task
+} // namespace rfidoor::task


### PR DESCRIPTION
Essa PR implemente a classe abstrata para Semaphores, além das classes de BinarySemaphore  e MutexSemaphore.

Todas as tasks têm acesso a todos os semáforos por meio do include do arquivo `semaphore_scheme.hpp`, arquivo onde todos os semaphores estão sendo instanciados.

Fiquei com uma dúvida que vou deixar bem onde é comentado 👍 